### PR TITLE
cv2 backwards compatibility

### DIFF
--- a/realtime_demo.py
+++ b/realtime_demo.py
@@ -129,9 +129,9 @@ class MatchingDemo:
     def draw_quad(self, frame, point_list):
         if len(self.corners) > 1:
             for i in range(len(self.corners) - 1):
-                cv2.line(frame, point_list[i], point_list[i + 1], self.line_color, self.line_thickness, lineType = self.line_type)
+                cv2.line(frame, tuple(point_list[i]), tuple(point_list[i + 1]), self.line_color, self.line_thickness, lineType = self.line_type)
             if len(self.corners) == 4:  # Close the quadrilateral if 4 corners are defined
-                cv2.line(frame, point_list[3], point_list[0], self.line_color, self.line_thickness, lineType = self.line_type)
+                cv2.line(frame, tuple(point_list[3]), tuple(point_list[0]), self.line_color, self.line_thickness, lineType = self.line_type)
 
     def mouse_callback(self, event, x, y, flags, param):
         if event == cv2.EVENT_LBUTTONDOWN:


### PR DESCRIPTION
Hello !

Thank you for your amazing work. I just tried out the code on my system and noticed the following bug:
```
root@ubuntu:/home/xavier01/Documents/workspace/embedded-vpr/accelerated_features# python3 realtime_demo.py --method XFeat
[ WARN:0] global /opt/opencv/modules/videoio/src/cap_gstreamer.cpp (935) open OpenCV | GStreamer warning: Cannot query video position: status=0, value=-1, duration=-1
[ WARN:0] global /opt/opencv/modules/videoio/src/cap_gstreamer.cpp (1186) setProperty OpenCV | GStreamer warning: GStreamer: unhandled property
loading weights from: /home/xavier01/Documents/workspace/embedded-vpr/accelerated_features/modules/../weights/xfeat.pt
loading weights from: /home/xavier01/Documents/workspace/embedded-vpr/accelerated_features/modules/../weights/xfeat.pt
Traceback (most recent call last):
  File "realtime_demo.py", line 295, in <module>
    demo.main_loop()
  File "realtime_demo.py", line 269, in main_loop
    self.process()
  File "realtime_demo.py", line 179, in process
    top_frame_canvas = self.create_top_frame()
  File "realtime_demo.py", line 173, in create_top_frame
    self.draw_quad(top_frame_canvas, self.corners)
  File "realtime_demo.py", line 132, in draw_quad
    cv2.line(frame, point_list[i], point_list[i + 1], self.line_color, self.line_thickness, lineType = self.line_type)
SystemError: new style getargs format but argument is not a tuple
```
Device: Nvidia Jetson AGX Xavier
Docker image: `dustynv/l4t-ml:r35.4.1`
`cv2` version: `4.5.0`
python3 version: `3.8.10`

This issue seems to be addressed in later versions of `cv2` specifically `4.9.0`. Adding this fix makes it invariant to the `cv2` version

Let me know if any further changes are required in this PR