### PR TITLE
Fix `align_corners` Configuration in `InterpolateSparse2d`

### DIFF
--- a/modules/interpolator.py
+++ b/modules/interpolator.py
@@ -29,5 +29,5 @@ class InterpolateSparse2d(nn.Module):
             [B, N, C] sampled channels at 2d positions
         """
         grid = self.normgrid(pos, H, W).unsqueeze(-2).to(x.dtype)
-        x = F.grid_sample(x, grid, mode = self.mode , align_corners = False)
+        x = F.grid_sample(x, grid, mode = self.mode , align_corners = self.align_corners)
         return x.permute(0,2,3,1).squeeze(-2)


### PR DESCRIPTION
This PR addresses a bug in the `InterpolateSparse2d` module where the `align_corners` parameter was not being correctly applied during the `grid_sample` operation. The fix ensures that the user-specified `align_corners` value is respected.